### PR TITLE
feat: don't replace context option, so it just runs default impl

### DIFF
--- a/actions/local_actions.py
+++ b/actions/local_actions.py
@@ -24,6 +24,7 @@ from auth.data.keys import get_keys
 from auth.data.schemad.opaque import get_setup
 from auth.define import refresh_exp, access_exp, id_exp
 from auth.token.build import create_tokens, finish_tokens
+from datacontext.context import DontReplaceContext
 from store import Store
 
 
@@ -71,7 +72,7 @@ async def admin_access(local_dsrc):
     )
     refresh_id = 5252626
     key_state = await get_keystate(local_dsrc)
-    keys = await get_keys(local_dsrc.store, key_state)
+    keys = await get_keys(DontReplaceContext(), local_dsrc.store, key_state)
     refresh_token, access_token, id_token = finish_tokens(
         refresh_id,
         refresh_save,

--- a/src/datacontext/context.py
+++ b/src/datacontext/context.py
@@ -23,7 +23,11 @@ class ContextError(Exception):
 
 
 class Context:
-    pass
+    dont_replace: bool = False
+
+
+class DontReplaceContext(Context):
+    dont_replace: bool = True
 
 
 def make_data_context(
@@ -70,6 +74,9 @@ def replace_context(func):
     doesn't alter any behavior, as it simply calls the implementing function."""
 
     def replace(ctx: Context, *args, **kwargs):
+        if ctx.dont_replace:
+            return func(ctx, *args, **kwargs)
+
         replace_func = getattr(ctx, func.__name__)
         return replace_func(ctx, *args, **kwargs)
 


### PR DESCRIPTION
Add attribute to Context called `dont_replace`. Before replacing, it checks if this is true. If it is, then it will just return the default implementation. This is useful when in a test/action you don't want to fully register and instantiate a Contexts class and include the registries, but are just running a single context function. An example usage is for generating an admin key for local testing.