### PR TITLE
More klassement routes: user per event, events per class and events per user

### DIFF
--- a/actions/local_actions.py
+++ b/actions/local_actions.py
@@ -184,7 +184,7 @@ async def test_update_points(local_dsrc):
 
 @pytest.mark.asyncio
 async def test_add_event(local_dsrc, faker: Faker):
-    faker.seed_instance(242424)
+    faker.seed_instance(3)
     async with get_conn(local_dsrc) as conn:
         users = await data.ud.get_all_usernames(conn)
 

--- a/src/apiserver/app/error.py
+++ b/src/apiserver/app/error.py
@@ -9,6 +9,7 @@ class ErrorKeys(StrEnum):
     REGISTER = "invalid_register"
     RANKING_UPDATE = "invalid_ranking_update"
     DATA = "invalid_data_load"
+    GET_CLASS = "invalid_get_class"
 
 
 class AppError(Exception):

--- a/src/apiserver/app/modules/ranking.py
+++ b/src/apiserver/app/modules/ranking.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import BaseModel
 from datetime import date
@@ -77,3 +77,37 @@ async def sync_publish_ranking(dsrc: Source, publish: bool):
         await data.special.update_class_points(
             conn, points_class.classification_id, publish
         )
+
+
+async def events_for_user(dsrc: Source, user_id: str, class_id: int):
+    async with data.get_conn(dsrc) as conn:
+        await data.special.update_class_points(
+            conn, training_class.classification_id, publish
+        )
+        await data.special.update_class_points(
+            conn, points_class.classification_id, publish
+        )
+
+
+async def class_id_or_recent(dsrc: Source, class_id: Optional[int], rank_type: Optional[str]) -> int:
+    if class_id is None and rank_type is None:
+        reason = f"Provide either class_id or rank_type query parameter!"
+        raise AppError(
+            err_type=ErrorKeys.GET_CLASS,
+            err_desc=reason,
+            debug_key="user_events_invalid_class",
+        )
+    elif class_id is None and rank_type not in {"training", "points"}:
+        reason = f"Ranking {rank_type} is unknown!"
+        raise AppError(
+            err_type=ErrorKeys.GET_CLASS,
+            err_desc=reason,
+            debug_key="user_events_bad_ranking",
+        )
+    elif class_id is None:
+        async with data.get_conn(dsrc) as conn:
+            class_id = (await data.classifications.most_recent_class_of_type(
+                conn, rank_type
+            )).classification_id
+
+    return class_id

--- a/src/apiserver/app/modules/ranking.py
+++ b/src/apiserver/app/modules/ranking.py
@@ -79,19 +79,11 @@ async def sync_publish_ranking(dsrc: Source, publish: bool):
         )
 
 
-async def events_for_user(dsrc: Source, user_id: str, class_id: int):
-    async with data.get_conn(dsrc) as conn:
-        await data.special.update_class_points(
-            conn, training_class.classification_id, publish
-        )
-        await data.special.update_class_points(
-            conn, points_class.classification_id, publish
-        )
-
-
-async def class_id_or_recent(dsrc: Source, class_id: Optional[int], rank_type: Optional[str]) -> int:
+async def class_id_or_recent(
+    dsrc: Source, class_id: Optional[int], rank_type: Optional[str]
+) -> int:
     if class_id is None and rank_type is None:
-        reason = f"Provide either class_id or rank_type query parameter!"
+        reason = "Provide either class_id or rank_type query parameter!"
         raise AppError(
             err_type=ErrorKeys.GET_CLASS,
             err_desc=reason,
@@ -106,8 +98,8 @@ async def class_id_or_recent(dsrc: Source, class_id: Optional[int], rank_type: O
         )
     elif class_id is None:
         async with data.get_conn(dsrc) as conn:
-            class_id = (await data.classifications.most_recent_class_of_type(
-                conn, rank_type
-            )).classification_id
+            class_id = (
+                await data.classifications.most_recent_class_of_type(conn, rank_type)
+            ).classification_id
 
     return class_id

--- a/src/apiserver/data/special.py
+++ b/src/apiserver/data/special.py
@@ -1,7 +1,3 @@
-from typing import List
-from datetime import date as date_type
-
-from pydantic import BaseModel, TypeAdapter
 from sqlalchemy import text, RowMapping
 from sqlalchemy.ext.asyncio import AsyncConnection
 
@@ -20,14 +16,15 @@ from schema.model import (
     C_EVENTS_ID,
     C_EVENTS_POINTS,
     USERDATA_TABLE,
-    CLASS_EVENTS_POINTS_TABLE, C_EVENTS_CATEGORY, C_EVENTS_DESCRIPTION,
+    CLASS_EVENTS_POINTS_TABLE,
+    C_EVENTS_CATEGORY,
+    C_EVENTS_DESCRIPTION,
 )
 from store.db import execute_catch_conn, row_cnt, all_rows
-from store.error import NoDataError
 
 
 async def update_class_points(
-        conn: AsyncConnection, class_id: int, publish: bool = False
+    conn: AsyncConnection, class_id: int, publish: bool = False
 ) -> int:
     """
     This is a complex query. What it does, in essence, is collect all the events related to a specific classification_id
@@ -160,15 +157,12 @@ def parse_user_events(user_events: list[RowMapping]) -> list[UserEvent]:
 
 
 async def user_events_in_class(
-        conn: AsyncConnection, user_id: str, class_id: int
+    conn: AsyncConnection, user_id: str, class_id: int
 ) -> list[UserEvent]:
-    query = text(
-        f"""
-        SELECT {C_EVENTS_ID}, {C_EVENTS_CATEGORY}, {C_EVENTS_DESCRIPTION}, {C_EVENTS_DATE}, {C_EVENTS_POINTS}
-        FROM {CLASS_POINTS_TABLE} as cp 
-        JOIN {CLASS_EVENTS_TABLE} as ce on cp.{C_EVENTS_ID} = ce.{C_EVENTS_ID} 
-        WHERE cp.{C_EVENTS_ID} = :class AND cp.{USER_ID} = :user;"""
-    )
+    query = text(f"""
+        SELECT cp.{C_EVENTS_ID}, {C_EVENTS_CATEGORY}, {C_EVENTS_DESCRIPTION}, {C_EVENTS_DATE}, {C_EVENTS_POINTS}
+        FROM {CLASS_EVENTS_POINTS_TABLE} as cp
+        JOIN {CLASS_EVENTS_TABLE} as ce on cp.{C_EVENTS_ID} = ce.{C_EVENTS_ID}
+        WHERE ce.{CLASS_ID} = :class AND cp.{USER_ID} = :user;""")
     res = await conn.execute(query, parameters={"class": class_id, "user": user_id})
     return parse_user_events(all_rows(res))
-

--- a/src/apiserver/lib/model/entities.py
+++ b/src/apiserver/lib/model/entities.py
@@ -207,10 +207,30 @@ class UserPointsNames(BaseModel):
     firstname: str
     lastname: str
     # In the database it is 'display_points'/'true_points', but we want to export as points
-    points: int = Field(validation_alias=AliasChoices("display_points", "true_points"))
+    # It might also just be points in the event_points table
+    points: int = Field(validation_alias=AliasChoices("display_points", "true_points", "points"))
 
 
 UserPointsNamesList = TypeAdapter(List[UserPointsNames])
 
-# class PointsData(BaseModel):
-#     points: int
+
+class ClassEvent(BaseModel):
+    event_id: str
+    category: str
+    description: str
+    date: date
+    points: int
+
+
+EventsList = TypeAdapter(List[ClassEvent])
+
+
+class UserEvent(BaseModel):
+    event_id: str
+    category: str
+    description: str
+    date: date
+    points: int
+
+
+UserEventsList = TypeAdapter(List[UserEvent])

--- a/src/apiserver/lib/model/entities.py
+++ b/src/apiserver/lib/model/entities.py
@@ -208,7 +208,9 @@ class UserPointsNames(BaseModel):
     lastname: str
     # In the database it is 'display_points'/'true_points', but we want to export as points
     # It might also just be points in the event_points table
-    points: int = Field(validation_alias=AliasChoices("display_points", "true_points", "points"))
+    points: int = Field(
+        validation_alias=AliasChoices("display_points", "true_points", "points")
+    )
 
 
 UserPointsNamesList = TypeAdapter(List[UserPointsNames])
@@ -219,7 +221,6 @@ class ClassEvent(BaseModel):
     category: str
     description: str
     date: date
-    points: int
 
 
 EventsList = TypeAdapter(List[ClassEvent])


### PR DESCRIPTION
This contains three new routes:

* `/admin/class/events/user/{user_id}/` is for getting all events of a user in a specific class, which can be given explicitly or just referred to as "points" or "training"
* `/admin/class/events/` returns all events in a class. Again either by explicitly giving the class id or ranking type.
* `/admin/class/events/{event_id}/` gets all users and their points for a specific event, using only the event_id. 

There was also some wrong syntax in the aggregation query, which e.g. affected `/admin/class/sync/` (previously `/admin/classification/sync/{publish}/`). This has now been fixed.

The only routes left are for modifying stuff. For modifying/adding a user to an event we already have a data function, but not yet a route.