### PR TITLE
Context tests and contextualize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,17 +40,16 @@ jobs:
         npm install
         npm run build
       working-directory: ${{ github.workspace }}/authpage
-    
+    - name: Pytest
+      run: poetry run pytest
+      env:
+        QUERY_TEST: true
     - name: Black
       run: poetry run black src tests
     - name: Ruff
       run: poetry run ruff src tests
     - name: Mypy
       run: poetry run mypy
-    - name: Pytest
-      run: poetry run pytest
-      env:
-        QUERY_TEST: true
     services:
       postgres:
         image: ghcr.io/dsav-dodeka/postgres:localdev

--- a/src/apiserver/app/modules/__init__.py
+++ b/src/apiserver/app/modules/__init__.py
@@ -1,0 +1,4 @@
+"""Modules encapsulate the different context functions in cases where the router function would become too complex.
+They should not know about HTTP (that is for the actual routers and possible router helper functions), hence they
+should raise only AppError exceptions and take in only model objects, a context and data source. They should NOT open
+connections directly, that is for the lower data context functions to do."""

--- a/src/apiserver/app_lifespan.py
+++ b/src/apiserver/app_lifespan.py
@@ -18,9 +18,12 @@ from apiserver.data import Source
 from apiserver.data.context import Code, SourceContexts
 from apiserver.data.context.register import ctx_reg as register_app_reg
 from apiserver.data.context.update import ctx_reg as update_reg
+from apiserver.data.context.ranking import ctx_reg as ranking_reg
+from apiserver.data.context.authorize import ctx_reg as authrz_app_reg
 from apiserver.define import LOGGER_NAME, DEFINE
 from apiserver.env import load_config, Config
 from apiserver.resources import res_path
+from datacontext.context import WrapContext
 
 logger = logging.getLogger(LOGGER_NAME)
 
@@ -91,8 +94,16 @@ def register_and_define_code() -> Code:
     source_data_context = SourceContexts()
     source_data_context.include_registry(register_app_reg)
     source_data_context.include_registry(update_reg)
+    source_data_context.include_registry(ranking_reg)
+    source_data_context.include_registry(authrz_app_reg)
 
-    return Code(auth_context=data_context, app_context=source_data_context)
+    wrap_data_context = WrapContext()
+
+    return Code(
+        auth_context=data_context,
+        app_context=source_data_context,
+        wrap=wrap_data_context,
+    )
 
 
 AppLifespan = Callable[[FastAPI], AsyncContextManager[State]]

--- a/src/apiserver/data/api/classifications.py
+++ b/src/apiserver/data/api/classifications.py
@@ -1,7 +1,6 @@
 from datetime import date, timedelta
 from typing import Literal
 
-from pydantic import BaseModel
 from sqlalchemy import RowMapping
 from sqlalchemy.ext.asyncio import AsyncConnection
 
@@ -9,6 +8,7 @@ from apiserver.lib.model.entities import (
     ClassEvent,
     Classification,
     ClassView,
+    UserPoints,
     UserPointsNames,
     UserPointsNamesList,
     EventsList,
@@ -169,11 +169,6 @@ async def upsert_user_event_points(
     await insert(conn, CLASS_EVENTS_POINTS_TABLE, row_to_insert)
 
 
-class UserPoints(BaseModel):
-    user_id: str
-    points: int
-
-
 async def add_users_to_event(
     conn: AsyncConnection, event_id: str, points: list[UserPoints]
 ) -> int:
@@ -209,6 +204,7 @@ async def events_in_class(conn: AsyncConnection, class_id: int) -> list[ClassEve
 async def get_event_user_points(
     conn: AsyncConnection, event_id: str
 ) -> list[UserPointsNames]:
+    """If resulting list is empty, either the event doesn't exist or it has no users in it."""
     user_id_select = f"{USERDATA_TABLE}.{USER_ID}"
     user_points = await select_some_join_where(
         conn,

--- a/src/apiserver/data/context/__init__.py
+++ b/src/apiserver/data/context/__init__.py
@@ -3,11 +3,23 @@ from apiserver.data.context.app_context import (
     Code,
     RegisterAppContext,
     UpdateContext,
+    RankingContext,
 )
 
 __all__ = [
     "SourceContexts",
     "RegisterAppContext",
     "UpdateContext",
+    "RankingContext",
     "Code",
 ]
+
+"""Context functions are the core of the application, as they should contain the majority of the stateful, impure code
+as they interact directly with the various database procedures. They can be called directly by router functions or by
+`modules` functions. They should be the ones that open connections. These functions should have as little business logic
+as possible, that should be handled by `lib` functions. You should not worry too much about testing these functions, as
+this can be challenging due to the many database calls. Instead, test the underlying data functions using query tests
+and the business logic in unit tests.
+
+Small business logic can be separated into functions inside the file. If it is also used by the router or other files,
+then move it into `lib`."""

--- a/src/apiserver/data/context/authorize.py
+++ b/src/apiserver/data/context/authorize.py
@@ -1,0 +1,23 @@
+from apiserver.app.error import ErrorResponse
+from apiserver.app.routers.helper.helper import handle_auth
+from apiserver.data.context.app_context import AuthorizeAppContext
+from apiserver.data.source import Source
+from datacontext.context import ContextRegistry
+
+
+ctx_reg = ContextRegistry()
+
+
+@ctx_reg.register(AuthorizeAppContext)
+async def require_admin(authorization: str, dsrc: Source) -> bool:
+    acc = await handle_auth(authorization, dsrc)
+    scope_set = set(acc.scope.split())
+    if "admin" not in scope_set:
+        raise ErrorResponse(
+            403,
+            err_type="insufficient_perms",
+            err_desc="Insufficient permissions to access this resource.",
+            debug_key="low_perms",
+        )
+    else:
+        return True

--- a/src/apiserver/data/context/ranking.py
+++ b/src/apiserver/data/context/ranking.py
@@ -1,0 +1,135 @@
+from datacontext.context import ContextRegistry
+from typing import Literal
+
+from store.error import DataError
+
+from apiserver.lib.model.entities import (
+    ClassEvent,
+    ClassView,
+    NewEvent,
+    UserEvent,
+    UserPointsNames,
+)
+from apiserver.data import Source
+from apiserver.data.api.classifications import (
+    add_class_event,
+    add_users_to_event,
+    all_points_in_class,
+    events_in_class,
+    get_event_user_points,
+    most_recent_class_of_type,
+)
+from apiserver.data.context import RankingContext
+from apiserver.data.source import get_conn
+from apiserver.data.special import update_class_points, user_events_in_class
+from apiserver.app.error import ErrorKeys, AppError
+
+
+ctx_reg = ContextRegistry()
+
+
+def check_add_to_class(classification: ClassView, new_event: NewEvent) -> None:
+    """Throws AppError if not correct."""
+    if classification.start_date > new_event.date:
+        desc = "Event cannot happen before start of classification!"
+        raise AppError(ErrorKeys.RANKING_UPDATE, desc, "ranking_date_before_start")
+
+
+@ctx_reg.register(RankingContext)
+async def add_new_event(dsrc: Source, new_event: NewEvent) -> None:
+    """Add a new event and recompute points. Display points will be updated to not include any events after the hidden
+    date. Use the 'publish' function to force them to be equal."""
+    async with get_conn(dsrc) as conn:
+        try:
+            classification = await most_recent_class_of_type(conn, new_event.class_type)
+        except DataError as e:
+            if e.key != "incorrect_class_type":
+                raise e
+            raise AppError(ErrorKeys.RANKING_UPDATE, e.message, "incorrect_class_type")
+
+        # THROWS AppError
+        check_add_to_class(classification, new_event)
+
+        event_id = await add_class_event(
+            conn,
+            new_event.event_id,
+            classification.classification_id,
+            new_event.category,
+            new_event.date,
+            new_event.description,
+        )
+
+        try:
+            await add_users_to_event(conn, event_id=event_id, points=new_event.users)
+        except DataError as e:
+            if e.key != "database_integrity":
+                raise e
+            raise AppError(
+                ErrorKeys.RANKING_UPDATE,
+                e.message,
+                "add_event_users_violates_integrity",
+            )
+
+        await update_class_points(
+            conn,
+            classification.classification_id,
+        )
+
+
+@ctx_reg.register(RankingContext)
+async def context_most_recent_class_id_of_type(
+    dsrc: Source, rank_type: Literal["points", "training"]
+) -> int:
+    async with get_conn(dsrc) as conn:
+        class_id = (await most_recent_class_of_type(conn, rank_type)).classification_id
+
+    return class_id
+
+
+@ctx_reg.register(RankingContext)
+async def context_most_recent_class_points(
+    dsrc: Source, rank_type: Literal["points", "training"], is_admin: bool
+) -> list[UserPointsNames]:
+    async with get_conn(dsrc) as conn:
+        class_view = await most_recent_class_of_type(conn, rank_type)
+        user_points = await all_points_in_class(
+            conn, class_view.classification_id, is_admin
+        )
+
+    return user_points
+
+
+@ctx_reg.register(RankingContext)
+async def sync_publish_ranking(dsrc: Source, publish: bool) -> None:
+    async with get_conn(dsrc) as conn:
+        training_class = await most_recent_class_of_type(conn, "training")
+        points_class = await most_recent_class_of_type(conn, "points")
+        await update_class_points(conn, training_class.classification_id, publish)
+        await update_class_points(conn, points_class.classification_id, publish)
+
+
+@ctx_reg.register(RankingContext)
+async def context_user_events_in_class(
+    dsrc: Source, user_id: str, class_id: int
+) -> list[UserEvent]:
+    async with get_conn(dsrc) as conn:
+        user_events = await user_events_in_class(conn, user_id, class_id)
+
+    return user_events
+
+
+@ctx_reg.register(RankingContext)
+async def context_events_in_class(dsrc: Source, class_id: int) -> list[ClassEvent]:
+    async with get_conn(dsrc) as conn:
+        events = await events_in_class(conn, class_id)
+
+    return events
+
+
+@ctx_reg.register(RankingContext)
+async def context_get_event_users(dsrc: Source, event_id: str) -> list[UserPointsNames]:
+    """If resulting list is empty, either the event doesn't exist or it has no users in it."""
+    async with get_conn(dsrc) as conn:
+        events_points = await get_event_user_points(conn, event_id)
+
+    return events_points

--- a/src/apiserver/lib/logic/ranking.py
+++ b/src/apiserver/lib/logic/ranking.py
@@ -1,0 +1,5 @@
+from typing import Literal, TypeGuard
+
+
+def is_rank_type(rank_type: str) -> TypeGuard[Literal["training", "points"]]:
+    return rank_type in {"training", "points"}

--- a/src/apiserver/lib/model/entities.py
+++ b/src/apiserver/lib/model/entities.py
@@ -246,3 +246,17 @@ class UserEvent(BaseModel):
 
 
 UserEventsList = TypeAdapter(List[UserEvent])
+
+
+class UserPoints(BaseModel):
+    user_id: str
+    points: int
+
+
+class NewEvent(BaseModel):
+    users: list[UserPoints]
+    class_type: Literal["points", "training"]
+    date: date
+    event_id: str
+    category: str
+    description: str = ""

--- a/tests/query_test/context_test.py
+++ b/tests/query_test/context_test.py
@@ -1,25 +1,15 @@
 import asyncio
-from datetime import date, datetime
 import os
 from uuid import uuid4
 
 import pytest
 import pytest_asyncio
 from sqlalchemy import Engine, create_engine, text
-from apiserver.data.api.classifications import insert_classification
 
 
 from apiserver.env import Config, load_config
 from schema.model import metadata as db_model
-from schema.model.model import (
-    CLASS_END_DATE,
-    CLASS_HIDDEN_DATE,
-    CLASS_START_DATE,
-    CLASS_TYPE,
-    CLASSIFICATION_TABLE,
-)
 from test_util import Fixture
-from store.conn import get_conn
 from store.store import Store
 from test_resources import res_path
 
@@ -86,21 +76,4 @@ async def new_db_store(api_config: Config, admin_engine: Engine):
         conn.execute(drop_db)
 
 
-@pytest.mark.asyncio
-async def test_create_class(new_db_store: Store):
-    async with get_conn(new_db_store) as conn:
-        await insert_classification(conn, "points", date(2022, 1, 1))
-
-        query = text(f"""
-        SELECT * FROM {CLASSIFICATION_TABLE};
-        """)
-
-        res = await conn.execute(query)
-
-        res_item = res.mappings().first()
-
-    assert res_item is not None
-    assert res_item[CLASS_TYPE] == "points"
-    assert res_item[CLASS_START_DATE] == datetime(2022, 1, 1, 0, 0)
-    assert res_item[CLASS_END_DATE] == datetime(2022, 5, 31, 0, 0)
-    assert res_item[CLASS_HIDDEN_DATE] == datetime(2022, 5, 1, 0, 0)
+# TODO add tests for context functions

--- a/tests/query_test/data_test.py
+++ b/tests/query_test/data_test.py
@@ -74,11 +74,11 @@ async def new_db_store(api_config: Config, admin_engine: Engine):
         await conn.run_sync(db_model.create_all)
         query = text(f"SELECT current_database();")
         res = await conn.execute(query)
-        print(res)
+        print(res.mappings().first())
 
         query_tbl = text(f"SELECT * FROM pg_catalog.pg_tables;")
         res_tbl = await conn.execute(query_tbl)
-        print(res_tbl)
+        print(res_tbl.mappings().first())
     # we don't run startup due to its overhead
     
     yield store
@@ -98,11 +98,11 @@ async def test_create_class(new_db_store: Store):
     async with get_conn(new_db_store) as conn:
         query_db = text(f"SELECT current_database();")
         res_db = await conn.execute(query_db)
-        print(res_db)
+        print(res_db.mappings().first())
 
         query_tbl = text(f"SELECT * FROM pg_catalog.pg_tables;")
         res_tbl = await conn.execute(query_tbl)
-        print(res_tbl)
+        print(res_tbl.mappings().first())
         
         await insert_classification(conn, "points", date(2022, 1, 1))
 

--- a/tests/query_test/data_test.py
+++ b/tests/query_test/data_test.py
@@ -70,10 +70,20 @@ async def new_db_store(api_config: Config, admin_engine: Engine):
     assert store.db is not None
     # create schema
     async with store.db.connect() as conn:
+        
         await conn.run_sync(db_model.create_all)
+        query = text(f"SELECT current_database();")
+        res = await conn.execute(query)
+        print(res)
+
+        query_tbl = text(f"SELECT * FROM pg_catalog.pg_tables;")
+        res_tbl = await conn.execute(query_tbl)
+        print(res_tbl)
     # we don't run startup due to its overhead
+    
     yield store
-    # Ensure connections are disposed and GC'd
+    
+    # ensure connections are disposed and GC'd
     if store.db is not None:
         await store.db.dispose()
     del store
@@ -86,6 +96,14 @@ async def new_db_store(api_config: Config, admin_engine: Engine):
 @pytest.mark.asyncio
 async def test_create_class(new_db_store: Store):
     async with get_conn(new_db_store) as conn:
+        query_db = text(f"SELECT current_database();")
+        res_db = await conn.execute(query_db)
+        print(res_db)
+
+        query_tbl = text(f"SELECT * FROM pg_catalog.pg_tables;")
+        res_tbl = await conn.execute(query_tbl)
+        print(res_tbl)
+        
         await insert_classification(conn, "points", date(2022, 1, 1))
 
         query = text(f"""

--- a/tests/query_test/data_test.py
+++ b/tests/query_test/data_test.py
@@ -68,7 +68,9 @@ async def new_db_store(api_config: Config, admin_engine: Engine):
     store.init_objects(modified_config)
     # we don't run startup due to its overhead
     yield store
-    # Ensure connections are GC'd
+    # Ensure connections are disposed and GC'd
+    if store.db is not None:
+        await store.db.dispose()
     del store
 
     with admin_engine.connect() as conn:

--- a/tests/query_test/data_test.py
+++ b/tests/query_test/data_test.py
@@ -56,7 +56,7 @@ def admin_engine(api_config) -> Fixture[Engine]:
 
 @pytest_asyncio.fixture
 async def new_db_store(api_config: Config, admin_engine: Engine):
-    db_name = f"db_{uuid4()}"
+    db_name = f"db_{uuid4()}".replace('-', '_')
 
     with admin_engine.connect() as conn:
         create_db = text(f"CREATE DATABASE {db_name}")

--- a/tests/query_test/data_test.py
+++ b/tests/query_test/data_test.py
@@ -60,7 +60,7 @@ async def new_db_store(api_config: Config, admin_engine: Engine):
     db_name = f"db_{uuid4()}".replace("-", "_")
 
     with admin_engine.connect() as conn:
-        create_db = text(f"CREATE DATABASE {db_name}")
+        create_db = text(f"CREATE DATABASE {db_name};")
         conn.execute(create_db)
 
     modified_config = api_config.model_copy(update={"DB_NAME": db_name})
@@ -78,7 +78,7 @@ async def new_db_store(api_config: Config, admin_engine: Engine):
 
         query_tbl = text(f"SELECT * FROM pg_catalog.pg_tables;")
         res_tbl = await conn.execute(query_tbl)
-        print(res_tbl.mappings().first())
+        print(res_tbl.mappings().all())
     # we don't run startup due to its overhead
     
     yield store
@@ -89,7 +89,7 @@ async def new_db_store(api_config: Config, admin_engine: Engine):
     del store
 
     with admin_engine.connect() as conn:
-        drop_db = text(f"DROP DATABASE {db_name}")
+        drop_db = text(f"DROP DATABASE {db_name};")
         conn.execute(drop_db)
 
 
@@ -102,7 +102,7 @@ async def test_create_class(new_db_store: Store):
 
         query_tbl = text(f"SELECT * FROM pg_catalog.pg_tables;")
         res_tbl = await conn.execute(query_tbl)
-        print(res_tbl.mappings().first())
+        print(res_tbl.mappings().all())
         
         await insert_classification(conn, "points", date(2022, 1, 1))
 

--- a/tests/query_test/data_test.py
+++ b/tests/query_test/data_test.py
@@ -10,6 +10,7 @@ from apiserver.data.api.classifications import insert_classification
 
 
 from apiserver.env import Config, load_config
+from schema.model import metadata as db_model
 from schema.model.model import (
     CLASS_END_DATE,
     CLASS_HIDDEN_DATE,
@@ -66,6 +67,10 @@ async def new_db_store(api_config: Config, admin_engine: Engine):
 
     store = Store()
     store.init_objects(modified_config)
+    assert store.db is not None
+    # create schema
+    async with store.db.connect() as conn:
+        await conn.run_sync(db_model.create_all)
     # we don't run startup due to its overhead
     yield store
     # Ensure connections are disposed and GC'd

--- a/tests/query_test/data_test.py
+++ b/tests/query_test/data_test.py
@@ -70,8 +70,7 @@ async def new_db_store(api_config: Config, admin_engine: Engine):
     assert store.db is not None
     # create schema
     async with store.db.connect() as conn:
-        
-        await conn.run_sync(db_model.create_all)
+        db_model.create_all(bind=store.db.sync_engine)
         query = text(f"SELECT current_database();")
         res = await conn.execute(query)
         print(res.mappings().first())
@@ -79,6 +78,7 @@ async def new_db_store(api_config: Config, admin_engine: Engine):
         query_tbl = text(f"SELECT * FROM pg_catalog.pg_tables;")
         res_tbl = await conn.execute(query_tbl)
         print(res_tbl.mappings().all())
+
     # we don't run startup due to its overhead
     
     yield store

--- a/tests/query_test/data_test.py
+++ b/tests/query_test/data_test.py
@@ -1,0 +1,95 @@
+import asyncio
+from datetime import date
+import os
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import Engine, create_engine, text
+from apiserver.data.api.classifications import insert_classification
+
+
+from apiserver.env import Config, load_config
+from schema.model.model import (
+    CLASS_END_DATE,
+    CLASS_HIDDEN_DATE,
+    CLASS_START_DATE,
+    CLASS_TYPE,
+    CLASSIFICATION_TABLE,
+)
+from test_util import Fixture
+from store.conn import get_conn
+from store.store import Store
+from test_resources import res_path
+
+if not os.environ.get("QUERY_TEST"):
+    pytest.skip(
+        "Skipping store_test as QUERY_TEST is not set.", allow_module_level=True
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def event_loop():
+    """Necessary for async tests with module-scoped fixtures"""
+    loop = asyncio.get_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="module")
+def api_config() -> Fixture[Config]:
+    test_config_path = res_path.joinpath("querytestenv.toml")
+    yield load_config(test_config_path)
+
+
+@pytest.fixture(scope="module")
+def admin_engine(api_config) -> Fixture[Engine]:
+    db_cluster = f"{api_config.DB_USER}:{api_config.DB_PASS}@{api_config.DB_HOST}:{api_config.DB_PORT}"
+    admin_db_url = f"{db_cluster}/{api_config.DB_NAME_ADMIN}"
+
+    admin_engine = create_engine(
+        f"postgresql+psycopg://{admin_db_url}", isolation_level="AUTOCOMMIT"
+    )
+
+    yield admin_engine
+
+
+@pytest_asyncio.fixture
+async def new_db_store(api_config: Config, admin_engine: Engine):
+    db_name = f"db_{uuid4()}"
+
+    with admin_engine.connect() as conn:
+        create_db = text(f"CREATE DATABASE {db_name}")
+        conn.execute(create_db)
+
+    modified_config = api_config.model_copy(update={"DB_NAME": db_name})
+
+    store = Store()
+    store.init_objects(modified_config)
+    # we don't run startup due to its overhead
+    yield store
+    # Ensure connections are GC'd
+    del store
+
+    with admin_engine.connect() as conn:
+        drop_db = text(f"DROP DATABASE {db_name}")
+        conn.execute(drop_db)
+
+
+async def test_create_class(new_db_store: Store):
+    async with get_conn(new_db_store) as conn:
+        await insert_classification(conn, "points", date(2022, 1, 1))
+
+        query = text(f"""
+        SELECT * FROM {CLASSIFICATION_TABLE};
+        """)
+
+        res = await conn.execute(query)
+
+        res_item = res.mappings().first()
+
+    assert res_item is not None
+    assert res_item[CLASS_TYPE] == "points"
+    assert res_item[CLASS_START_DATE] == date(2022, 1, 1)
+    assert res_item[CLASS_END_DATE] == date(2022, 5, 31)
+    assert res_item[CLASS_HIDDEN_DATE] == date(2022, 5, 1)

--- a/tests/query_test/data_test.py
+++ b/tests/query_test/data_test.py
@@ -56,7 +56,7 @@ def admin_engine(api_config) -> Fixture[Engine]:
 
 @pytest_asyncio.fixture
 async def new_db_store(api_config: Config, admin_engine: Engine):
-    db_name = f"db_{uuid4()}".replace('-', '_')
+    db_name = f"db_{uuid4()}".replace("-", "_")
 
     with admin_engine.connect() as conn:
         create_db = text(f"CREATE DATABASE {db_name}")
@@ -76,6 +76,7 @@ async def new_db_store(api_config: Config, admin_engine: Engine):
         conn.execute(drop_db)
 
 
+@pytest.mark.asyncio
 async def test_create_class(new_db_store: Store):
     async with get_conn(new_db_store) as conn:
         await insert_classification(conn, "points", date(2022, 1, 1))

--- a/tests/router_test/ranking_test.py
+++ b/tests/router_test/ranking_test.py
@@ -1,0 +1,111 @@
+from contextlib import asynccontextmanager
+
+import pytest
+from faker import Faker
+from fastapi import FastAPI
+from pytest_mock import MockerFixture
+from sqlalchemy.ext.asyncio import AsyncConnection
+from starlette.testclient import TestClient
+
+from apiserver.app_def import create_app
+from apiserver.app_lifespan import safe_startup, register_and_define_code
+from apiserver.data import Source
+from apiserver.data.context import Code
+from apiserver.data.context.app_context import AuthorizeAppContext
+from apiserver.env import load_config
+from apiserver.lib.model.entities import UserPointsNames
+from datacontext.context import WrapContext
+from test_util import (
+    make_test_user,
+    make_base_ud,
+)
+from test_resources import res_path
+
+
+@pytest.fixture
+def gen_user(faker: Faker):
+    yield make_test_user(faker)
+
+
+@pytest.fixture
+def gen_ud_u(faker: Faker):
+    yield make_base_ud(faker)
+
+
+@pytest.fixture(scope="module")
+def api_config():
+    test_config_path = res_path.joinpath("testenv.toml")
+    yield load_config(test_config_path)
+
+
+@pytest.fixture(scope="module")
+def make_dsrc(module_mocker: MockerFixture):
+    dsrc_inst = Source()
+    store_mock = module_mocker.MagicMock(spec=dsrc_inst.store)
+    store_mock.db.connect = module_mocker.MagicMock(
+        return_value=module_mocker.MagicMock(spec=AsyncConnection)
+    )
+    dsrc_inst.store = store_mock
+
+    yield dsrc_inst
+
+
+@pytest.fixture(scope="module")
+def make_cd():
+    cd = register_and_define_code()
+    yield cd
+
+
+@pytest.fixture(scope="module")
+def lifespan_fixture(api_config, make_dsrc: Source, make_cd: Code):
+    safe_startup(make_dsrc, api_config)
+
+    @asynccontextmanager
+    async def mock_lifespan(app: FastAPI):
+        yield {"dsrc": make_dsrc, "cd": make_cd}
+
+    yield mock_lifespan
+
+
+@pytest.fixture(scope="module")
+def app(lifespan_fixture):
+    # startup, shutdown is not run
+    apiserver_app = create_app(lifespan_fixture)
+    yield apiserver_app
+
+
+@pytest.fixture(scope="module")
+def test_client(app):
+    with TestClient(app=app) as test_client:
+        yield test_client
+
+
+def mock_authrz_ctx():
+    class MockAuthorizeAppContext(AuthorizeAppContext):
+        @classmethod
+        async def require_admin(cls, authorization: str, dsrc: Source) -> bool:
+            return True
+
+    return MockAuthorizeAppContext()
+
+
+def mock_wrap_ctx():
+    class MockWrapContext(WrapContext):
+        @classmethod
+        async def get_event_user_points(
+            cls, dsrc: Source, event_id: str
+        ) -> list[UserPointsNames]:
+            return list()
+
+    return MockWrapContext()
+
+
+def test_get_events_in_class(
+    test_client: TestClient,
+    make_cd: Code,
+):
+    make_cd.wrap = mock_wrap_ctx()
+    make_cd.app_context.authrz_ctx = mock_authrz_ctx()
+    headers = {"Authorization": "something"}
+    response = test_client.get(f"/admin/class/users/event/{3}/", headers=headers)
+    assert response.json() == []


### PR DESCRIPTION
This PR adds everything necessary to write tests for the functions in `apiserver/data/context`, i.e. the ones that can be overridden easily for testing using Context (the current version introduced in #64). It also adds an initial routing test and some docs on when/how to use modules vs context functions.

* Modules are for complex interactions that use many different context functions, particularly in the case where context functions could be reused in multiple ways. They should not know about HTTP or how the context functions get their data (i.e. shouldn't call the `data/api` functions) and should not instantiate any connections themselves. This is still a somewhat leaky abstraction, as we still have `source_session`. Modules should be tested, as they only call context functions which can be easily replaced in tests.
* Context functions should call the data API functions (`data/api`) and other functions if they need business logic. The amount of logic should be minimized, they should really be all about loading and storing data. If possible, logic should be separated into different functions that can be easily unit tested. Context functions shouldn't really need to be tested, but the functions they call should be.

Sometimes, a router or module wants to directly call just a single `data/api` function. To make it testable, they should only call context functions. However, this adds an additional layer between the data API functions and using them and it is quite a lot of boilerplate to copy them, instantiate connections, add typing, add context stubs, etc. So, a new solution was invented:
* `ctxlize` is a new function in the `datacontext` package. It takes any function and a wrapper function and then allows it to be called with a WrapContext. The arguments can be transformed in an arbitrary way by the wrapper function, which is defined at the application level. We use it to turn the AsyncConnection argument into a Source argument by instantiating a connection in the wrapper function. Example:
```python
# Original function
async def get_event_user_points(
    conn: AsyncConnection, event_id: str
)
```
```python
# Calling it using ctxlize, dsrc is of Source type
event_users = await ctxlize(get_event_user_points, conn_wrap)(
        cd.wrap, dsrc, event_id
)
```
```python
# conn_wrap definition (types have been collapsed)
# `c` is original function
def conn_wrap(c):
    async def wrapped(r: Source, *args, **kwargs):
        async with get_conn(r) as conn:
            return await c(conn, *args, **kwargs)

    return wrapped
```
It doesn't require stubs to be written nor a decorator on the original function. You simply create a WrapContext for each test and add only the functions you want to change to it and then replace the `wrap` attribute of the app's Code object. This means you do have to check yourself that they match properly, this isn't checked like it is for the usual way of creating context functions. The types look quite complicated but if you use it with Pylance in VS Code it should work quite well.

Some functions still need to be switched to this. Also, the `require_admin` etc. needs proper context functions and probably some refactoring. But for now this should be enough.